### PR TITLE
make battery state configureable

### DIFF
--- a/battery_state_broadcaster/include/semantic_components/battery_state.hpp
+++ b/battery_state_broadcaster/include/semantic_components/battery_state.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <rclcpp/rclcpp.hpp>
 #include <semantic_components/semantic_component_interface.hpp>
@@ -26,28 +27,35 @@ namespace semantic_components
 class BatteryState : public SemanticComponentInterface<sensor_msgs::msg::BatteryState>
 {
 public:
-  explicit BatteryState(const std::string & name)
-  : SemanticComponentInterface(name, 6)
+  explicit BatteryState(const std::string & name, const std::vector<std::string> & interfaces)
+  : SemanticComponentInterface(name, interfaces.size())
   {
-    this->interface_names_.emplace_back(this->name_ + "/" + "voltage");
-    this->interface_names_.emplace_back(this->name_ + "/" + "temperature");
-    this->interface_names_.emplace_back(this->name_ + "/" + "current");
-    this->interface_names_.emplace_back(this->name_ + "/" + "charge");
-    this->interface_names_.emplace_back(this->name_ + "/" + "capacity");
-    this->interface_names_.emplace_back(this->name_ + "/" + "percentage");
+    for (const auto & interface : interfaces) {
+      this->interface_names_.emplace_back(this->name_ + "/" + interface);
+    }
   }
 
   virtual ~BatteryState() = default;
 
   bool get_value_as_message(sensor_msgs::msg::BatteryState & message)
   {
-    message.voltage = state_interfaces_[0].get().get_value();
-    message.temperature = state_interfaces_[1].get().get_value();
-    message.current = state_interfaces_[2].get().get_value();
-    message.charge = state_interfaces_[3].get().get_value();
-    message.capacity = state_interfaces_[4].get().get_value();
-    message.percentage = state_interfaces_[5].get().get_value();
-
+    for (const auto & state_interface : this->state_interfaces_) {
+      const auto & name = state_interface.get().get_name();
+      const auto & value = state_interface.get().get_value();
+      if (name == "voltage") {
+        message.voltage = value;
+      } else if (name == "temperature") {
+        message.temperature = value;
+      } else if (name == "charge") {
+        message.charge = value;
+      } else if (name == "current") {
+        message.current = value;
+      } else if (name == "capacity") {
+        message.capacity = value;
+      } else if (name == "percentage") {
+        message.percentage = value;
+      }
+    }
     return false;
   }
 };

--- a/battery_state_broadcaster/src/battery_state_broadcaster.cpp
+++ b/battery_state_broadcaster/src/battery_state_broadcaster.cpp
@@ -37,14 +37,13 @@ controller_interface::CallbackReturn BatteryStateBroadcaster::on_configure(
   this->params_ = this->param_listener_->get_params();
 
   this->battery_state_ = std::make_unique<semantic_components::BatteryState>(
-    semantic_components::BatteryState(this->params_.sensor_name));
+    semantic_components::BatteryState(this->params_.sensor_name, this->params_.state_interfaces));
 
   try {
     // register ft sensor data publisher
     this->sensor_state_publisher_ =
       get_node()->create_publisher<sensor_msgs::msg::BatteryState>(
-      "~/battery",
-      rclcpp::SensorDataQoS());
+      "~/battery_state", rclcpp::SensorDataQoS());
     this->realtime_publisher_ = std::make_unique<StatePublisher>(this->sensor_state_publisher_);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(
@@ -58,6 +57,12 @@ controller_interface::CallbackReturn BatteryStateBroadcaster::on_configure(
 
   this->realtime_publisher_->msg_.header.frame_id = this->params_.frame_id;
   this->realtime_publisher_->msg_.design_capacity = this->params_.design_capacity;
+  this->realtime_publisher_->msg_.voltage = std::numeric_limits<float>::quiet_NaN();
+  this->realtime_publisher_->msg_.temperature = std::numeric_limits<float>::quiet_NaN();
+  this->realtime_publisher_->msg_.charge = std::numeric_limits<float>::quiet_NaN();
+  this->realtime_publisher_->msg_.current = std::numeric_limits<float>::quiet_NaN();
+  this->realtime_publisher_->msg_.capacity = std::numeric_limits<float>::quiet_NaN();
+  this->realtime_publisher_->msg_.percentage = std::numeric_limits<float>::quiet_NaN();
   this->realtime_publisher_->msg_.power_supply_status = this->params_.power_supply_status;
   this->realtime_publisher_->msg_.power_supply_health = this->params_.power_supply_health;
   this->realtime_publisher_->msg_.power_supply_technology = this->params_.power_supply_technology;

--- a/battery_state_broadcaster/src/battery_state_broadcaster_parameters.yaml
+++ b/battery_state_broadcaster/src/battery_state_broadcaster_parameters.yaml
@@ -3,6 +3,23 @@ battery_state_broadcaster:
     type: string
     description: "Name of the sensor used as prefix for interfaces if there are no individual interface names defined."
     default_value: "battery_sensor"
+  state_interfaces:
+    type: string_array
+    default_value: ["percentage"]
+    validation:
+      not_empty<>: []
+      size_lt<>: 6
+      subset_of<>:
+        [
+          [
+            "voltage",
+            "temperature",
+            "current",
+            "charge",
+            "capacity",
+            "percentage",
+          ],
+        ]
   frame_id:
     type: string
     description: "Sensor's frame_id in which values are published."

--- a/battery_state_broadcaster/test/test_battery_state_broadcaster.cpp
+++ b/battery_state_broadcaster/test/test_battery_state_broadcaster.cpp
@@ -34,7 +34,7 @@ void BatteryStateBroadcasterTest::SetUp()
   this->btr_broadcaster_ = std::make_unique<FriendBatteryStateBroadcaster>();
   this->values_.resize(6, std::numeric_limits<double>::quiet_NaN());
 
-  for (uint i = 0; i < 6; i++) {
+  for (uint i = 0; i < this->state_interface_names.size(); i++) {
     state_interfaces_.emplace_back(
       hardware_interface::StateInterface(
         this->sensor_name_, this->state_interface_names[i], &this->values_[i]));
@@ -66,7 +66,7 @@ void BatteryStateBroadcasterTest::subscribe_and_get_message(
   rclcpp::Node test_subscription_node("test_subscription_node");
   auto subs_callback = [&](const sensor_msgs::msg::BatteryState::SharedPtr) {};
   auto subscription = test_subscription_node.create_subscription<sensor_msgs::msg::BatteryState>(
-    "/test_battery_state_broadcaster/battery", rclcpp::SensorDataQoS(), subs_callback);
+    "/test_battery_state_broadcaster/battery_state", rclcpp::SensorDataQoS(), subs_callback);
 
   int max_sub_check_loop_count = 5;
   rclcpp::WaitSet wait_set;

--- a/battery_state_broadcaster/test/test_battery_state_broadcaster.hpp
+++ b/battery_state_broadcaster/test/test_battery_state_broadcaster.hpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 
@@ -42,12 +43,12 @@ class BatteryStateBroadcasterTest : public ::testing::Test
 protected:
   const std::string sensor_name_ = "btr_sensor";
   const std::string frame_id_ = "btr_frame";
-  const _Float32 voltage_ = 3.4;
-  const _Float32 temperature_ = 24.5;
-  const _Float32 current_ = 0.5;
-  const _Float32 charge_ = 24.1;
-  const _Float32 capacity_ = 4.8;
-  const _Float32 percentage_ = 0.7;
+  const float voltage_ = 3.4;
+  const float temperature_ = 24.5;
+  const float current_ = 0.5;
+  const float charge_ = 24.1;
+  const float capacity_ = 4.8;
+  const float percentage_ = 0.7;
 
   const std::array<std::string, 6> state_interface_names = {
     "voltage", "temperature", "current", "charge", "capacity", "percentage"


### PR DESCRIPTION
Now the battery state_interface can be configurable from `state_interfaces` parameter