### PR TITLE
fix how to get interface name & params setting

### DIFF
--- a/battery_state_broadcaster/include/semantic_components/battery_state.hpp
+++ b/battery_state_broadcaster/include/semantic_components/battery_state.hpp
@@ -40,7 +40,7 @@ public:
   bool get_value_as_message(sensor_msgs::msg::BatteryState & message)
   {
     for (const auto & state_interface : this->state_interfaces_) {
-      const auto & name = state_interface.get().get_name();
+      const auto & name = state_interface.get().get_interface_name();
       const auto & value = state_interface.get().get_value();
       if (name == "voltage") {
         message.voltage = value;

--- a/battery_state_broadcaster/src/battery_state_broadcaster_parameters.yaml
+++ b/battery_state_broadcaster/src/battery_state_broadcaster_parameters.yaml
@@ -8,7 +8,7 @@ battery_state_broadcaster:
     default_value: ["percentage"]
     validation:
       not_empty<>: []
-      size_lt<>: 6
+      size_lt<>: 7
       subset_of<>:
         [
           [


### PR DESCRIPTION
### fix how to get interface name 
- for example 
  .get_name() -> "battery_sensor/percentage"
  .get_interface_name() -> "percentage"
### fix params setting